### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ Two values are required for Bastille to use ZFS. The default values in the
 ## ZFS options
 bastille_zfs_enable=""                                  ## default: ""
 bastille_zfs_zpool=""                                   ## default: ""
-bastille_zfs_prefix="bastille"                          ## default: "${bastille_zfs_zpool}/bastille"
-bastille_zfs_mountpoint=${bastille_prefix}              ## default: "${bastille_prefix}"
+bastille_zfs_prefix="bastille"                          ## default: "bastille"
 bastille_zfs_options="-o compress=lz4 -o atime=off"     ## default: "-o compress=lz4 -o atime=off"
 ```
 


### PR DESCRIPTION
1. Based on January 20, 2020 issues/updates, the variable bastille_zfs_mountpoint was removed from the /usr/local/etc/bastille/bastille.conf[.sample] file, and is not referenced anywhere else in the codebase. Remove text from README.md to match code.
2. bastille_zfs_prefix default value looks like is just "bastille" instead of "${bastille_zfs_zpool}/bastille" (also need to edit source file). I need to test more on the .conf file and will suggest a new bastile.conf.zfssample file to be added to make a new user's install easier on top of a default FreeBSD 12.2-RELEASE install with zfs.